### PR TITLE
Some small changes and fixes(?)

### DIFF
--- a/cydets/algorithm.py
+++ b/cydets/algorithm.py
@@ -404,6 +404,6 @@ def calc_doc(series, rows):
     doc = np.zeros(num)
 
     for c in range(num):
-        doc[c] = min(series[rows[c, 0]], series[rows[c, 1]]) - rows[c, 3]
+        doc[c] = min(series.iloc[int(rows[c, 0])], series.iloc[int(rows[c, 1])]) - rows[c, 3]
 
     return doc

--- a/cydets/algorithm.py
+++ b/cydets/algorithm.py
@@ -64,7 +64,7 @@ def detect_cycles(series, drop_zero_amplitudes=True):
         msg = ('The number of elements in the input time series to form one '
                'cycle must be 4 at least.')
         raise ValueError(msg)
-    # read input data from .csv file
+    # convert input data to a data frame
     series = series.to_frame(name='values')
 
     # norm input data

--- a/cydets/algorithm.py
+++ b/cydets/algorithm.py
@@ -66,6 +66,7 @@ def detect_cycles(series, drop_zero_amplitudes=True):
         raise ValueError(msg)
     # convert input data to a data frame
     series = series.to_frame(name='values')
+    series.index = pd.RangeIndex(len(series.index))
 
     # norm input data
     series['norm'] = series['values'] - series['values'].min()
@@ -103,7 +104,7 @@ def detect_cycles(series, drop_zero_amplitudes=True):
         df = df.drop(df[df['doc'] == 0].index)
 
     # reset the index
-    df = df.reset_index()
+    df = df.reset_index(drop=True)
 
     return df
 

--- a/cydets/algorithm.py
+++ b/cydets/algorithm.py
@@ -66,6 +66,7 @@ def detect_cycles(series, drop_zero_amplitudes=True):
         raise ValueError(msg)
     # convert input data to a data frame
     series = series.to_frame(name='values')
+    series['id'] = series.index
     series.index = pd.RangeIndex(len(series.index))
 
     # norm input data
@@ -93,9 +94,9 @@ def detect_cycles(series, drop_zero_amplitudes=True):
 
     # write data to DataFrame
     df = pd.DataFrame()
-    df['t_start'] = cycles[:, 0]
-    df['t_end'] = cycles[:, 1]
-    df['t_minimum'] = cycles[:, 2]
+    df['t_start'] = series.iloc[cycles[:, 0]]['id'].values
+    df['t_end'] = series.iloc[cycles[:, 1]]['id'].values
+    df['t_minimum'] = series.iloc[cycles[:, 2]]['id'].values
     df['doc'] = cycles[:, 3]
     df['duration'] = df['t_end'] - df['t_start']
 
@@ -409,6 +410,6 @@ def calc_doc(series, rows):
     doc = np.zeros(num)
 
     for c in range(num):
-        doc[c] = min(series.iloc[int(rows[c, 0])], series.iloc[int(rows[c, 1])]) - rows[c, 3]
+        doc[c] = min(series[rows[c, 0]], series[rows[c, 1]]) - rows[c, 3]
 
     return doc

--- a/cydets/algorithm.py
+++ b/cydets/algorithm.py
@@ -69,7 +69,11 @@ def detect_cycles(series, drop_zero_amplitudes=True):
 
     # norm input data
     series['norm'] = series['values'] - series['values'].min()
-    series['norm'] /= series['norm'].max()
+    maximum = series['norm'].max()
+    if maximum == 0:
+        msg = 'Detected constant time series.'
+        raise ValueError(msg)
+    series['norm'] /= maximum
 
     # find minima and maxima
     min_idx, max_idx = find_peaks_valleys_idx(series['norm'])

--- a/tests/test_cycling.py
+++ b/tests/test_cycling.py
@@ -3,7 +3,7 @@ import pandas as pd
 from nose.tools import eq_, raises
 from cydets.algorithm import detect_cycles
 from pandas.util.testing import assert_frame_equal
-from datetime import datetime, timedelta
+from datetime import datetime
 
 
 class TestErrors():

--- a/tests/test_cycling.py
+++ b/tests/test_cycling.py
@@ -2,6 +2,7 @@
 import pandas as pd
 from nose.tools import eq_, raises
 from cydets.algorithm import detect_cycles
+from pandas.util.testing import assert_frame_equal
 
 
 class TestErrors():
@@ -57,3 +58,24 @@ class TestExamples():
             cycles = detect_cycles(self.df[column])
             result = cycles.sum().sum()  # sum along column sums (kind of ID)
             eq_(result, expected, 'Test for example ' + column + ' failed.')
+
+
+class TestTimeIndex():
+    """Check if a timedate index is handled correctly."""
+
+    def __init__(self):
+        """Create the same dataframes as TestExamples with another index."""
+        twoTimesLong = [0, 1, 0, -1, 0, 1, 0, -1, 0, 1, 0]
+        index = pd.date_range(start='01.01.2019', freq='1d',
+                periods=len(twoTimesLong))
+        self.ds = pd.Series(twoTimesLong, index=index)
+
+    def test_example(self):
+        """Apply algorithm and check expected results."""
+        cycles = detect_cycles(self.ds)
+        # I just took the current results and assume they are correct
+        expected = pd.DataFrame([
+                [0, 1.0, 5.0, 3.0, 1.0, 4.0],
+                [1, 5.0, 9.0, 7.0, 1.0, 4.0],
+                ], columns=['index', 't_start', 't_end', 't_minimum', 'doc', 'duration'])
+        assert_frame_equal(cycles, expected)


### PR DESCRIPTION
Hi, here are a couple of changes that I came up with. Details are in the commit message.

Note that the last commit makes `TestErrors.test_ValueError_no_peak` fail for "the wrong reason": Instead of failing because of "there is no peak", it now fails because of the constant value. I failed at coming up with a test that actually fails because of no peak and then ran out of patience. Everything I tried instead failed because of missing precycles.

Feel free to do something about my `.iloc(int(index)` construction in the first patch. I tried to change the code to directly produce integers for the indicies instead of floats, but again: I failed and ran out of patience. The main problem here is that a single numpy array is used for saving a single cycle, so the index and the dod end up with the same data type.

Also: Feel free to treat this as three issue reports instead of a PR. Or to cherry pick commits from the PR and treat the rest as issues that you fix in a different way.